### PR TITLE
apache commons brukes til epost-validering

### DIFF
--- a/Epostadresse.textile
+++ b/Epostadresse.textile
@@ -11,7 +11,7 @@ group: Oppslagstjenesten/complexType
 - Definisjon := Informasjon om en Person sitt Epostadresse registrert i kontakt og reservasjonsregisteret
 - Datatype := complexType
 - Kilde := DIFI
-- Kommentar := Informasjon om en Person sitt Epostadresse registrert i kontakt og reservasjonsregisteret
+- Kommentar := Informasjon om en Person sitt Epostadresse registrert i kontakt og reservasjonsregisteret. Epost-addressen blir validert vha. biblioteket "Apache Commons":http://commons.apache.org/proper/commons-validator/
 
 h4. Attributer
 


### PR DESCRIPTION
oppdaterer dokumentasjonen ihht praksis.
